### PR TITLE
fix: Capitalization and addition of `Enterprise` in install_linux

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -37,7 +37,7 @@ sudo apt update
 sudo apt install gh
 ```
 
-### Fedora, Centos, Red Hat Linux (dnf)
+### Fedora, CentOS, Red Hat Enterprise Linux (dnf)
 
 Install:
 


### PR DESCRIPTION
Capitalized: `OS` of `CentOS`
Addition of `Enterprise` in `Redhat Linux`